### PR TITLE
Pass trash target and trash args to prevention functions

### DIFF
--- a/src/clj/game/cards/events.clj
+++ b/src/clj/game/cards/events.clj
@@ -1378,7 +1378,7 @@
                                (set-prop state side (get-card state target) :agendapoints (+ amount (:agendapoints (get-card state target))))
                                (gain-agenda-point state side amount))]
      {:req (req archives-runnable)
-      :events {:purge {:effect (effect (trash card))}}
+      :events {:purge {:effect (effect (trash card {:cause :purge}))}}
       :trash-effect {:effect (req (let [current-side (get-scoring-owner state {:cid (:agenda-cid card)})]
                                     (update-agenda-points state current-side (find-cid (:agenda-cid card) (get-in @state [current-side :scored])) 1)))}
       :effect (effect (run :archives

--- a/src/clj/game/cards/programs.clj
+++ b/src/clj/game/cards/programs.clj
@@ -85,7 +85,7 @@
                                                   (turn-events state :corp :corp-install)))]
                    (swap! state assoc-in [:corp :register :cannot-score] agendas)))
     :events {:purge {:effect (req (swap! state update-in [:corp :register] dissoc :cannot-score)
-                                  (trash state side card))}
+                                  (trash state side card {:cause :purge}))}
              :corp-install {:req (req (is-type? target "Agenda"))
                             :effect (req (swap! state update-in [:corp :register :cannot-score] #(cons target %)))}}
     :leave-play (req (swap! state update-in [:corp :register] dissoc :cannot-score))}
@@ -261,7 +261,7 @@
    {:prompt "Choose the server that this copy of Diwan is targeting:"
     :choices (req servers)
     :effect (effect (update! (assoc card :server-target target)))
-    :events {:purge {:effect (effect (trash card))}
+    :events {:purge {:effect (effect (trash card {:cause :purge}))}
              :pre-corp-install {:req (req (let [c target
                                                 serv (:server (second targets))]
                                             (and (= serv (:server-target card))
@@ -349,7 +349,7 @@
 
    "eXer"
    {:in-play [:rd-access 1]
-    :events {:purge {:effect (effect (trash card))}} }
+    :events {:purge {:effect (effect (trash card {:cause :purge}))}}}
 
    "Expert Schedule Analyzer"
    {:abilities [{:cost [:click 1]
@@ -489,7 +489,7 @@
    "Ixodidae"
    {:events {:corp-loss {:req (req (= (first target) :credit)) :msg "gain 1 [Credits]"
                          :effect (effect (gain :runner :credit 1))}
-             :purge {:effect (effect (trash card))}}}
+             :purge {:effect (effect (trash card {:cause :purge}))}}}
 
    "Keyhole"
    {:abilities [{:cost [:click 1]
@@ -509,7 +509,7 @@
    "Lamprey"
    {:events {:successful-run {:req (req (= target :hq)) :msg "force the Corp to lose 1 [Credits]"
                               :effect (effect (lose :corp :credit 1))}
-             :purge {:effect (effect (trash card))}}}
+             :purge {:effect (effect (trash card {:cause :purge}))}}}
 
    "Leprechaun"
    {:abilities [{:label "Install a program on Leprechaun"
@@ -963,7 +963,7 @@
       :flags {:drip-economy true}
       :abilities [ability]
       :events {:runner-turn-begins ability
-               :purge {:effect (effect (trash card))}}})
+               :purge {:effect (effect (trash card {:cause :purge}))}}})
 
    "Tracker"
    (let [ability {:prompt "Choose a server for Tracker" :choices (req servers)

--- a/src/clj/game/cards/resources.clj
+++ b/src/clj/game/cards/resources.clj
@@ -636,7 +636,7 @@
                                   :effect (effect (move target :discard)
                                                   (trash-prevent (keyword type) 1))})]
      {:interactions {:prevent [{:type [:trash-hardware :trash-resource :trash-program]
-                                :req (req true)}]}
+                                :req (req (not= :purge (:cause target)))}]}
       :abilities [(dummy-prevent "hardware")
                   (dummy-prevent "resource")
                   (dummy-prevent "program")]})

--- a/src/clj/game/core/flags.clj
+++ b/src/clj/game/core/flags.clj
@@ -438,11 +438,11 @@
   "Checks if the specified ability definition should prevent.
   Checks for a :req in the :prevent map of the card-def.
   Defaults to false if req check not met"
-  ([state side card req-fn]
-   (ab-can-prevent? state side (make-eid state) card req-fn))
-  ([state side eid card req-fn]
+  ([state side card req-fn target args]
+   (ab-can-prevent? state side (make-eid state) card req-fn target args))
+  ([state side eid card req-fn target args]
    (cond
-     req-fn (req-fn state side eid card nil)
+     req-fn (req-fn state side eid card (list (assoc args :prevent-target target)))
      :else false)))
 
 (defn get-card-prevention
@@ -453,14 +453,15 @@
 
 (defn card-can-prevent?
   "Checks if a cards req (truthy test) can be met for this type"
-  [state side card type]
+  [state side card type target args]
   (let [abilities (get-card-prevention card type)]
-    (some #(-> % false? not) (map #(ab-can-prevent? state side card (:req %)) abilities))))
+    (some #(-> % false? not) (map #(ab-can-prevent? state side card (:req %) target args) abilities))))
 
 (defn cards-can-prevent?
   "Checks if any cards in a list can prevent this type"
-  [state side cards type]
-  (some #(true? %) (map #(card-can-prevent? state side % type) cards)))
+  ([state side cards type] (cards-can-prevent? state side cards type nil nil))
+  ([state side cards type target args]
+  (some #(true? %) (map #(card-can-prevent? state side % type target args) cards))))
 
 (defn get-prevent-list
   "Get list of cards that have prevent for a given type"

--- a/src/clj/game/core/rules.clj
+++ b/src/clj/game/core/rules.clj
@@ -416,7 +416,7 @@
          (let [type (->> ktype name (str "trash-") keyword)
                prevent (get-prevent-list state :runner type)]
            ;; Check for prevention effects
-           (if (and (not unpreventable) (not= cause :ability-cost) (cards-can-prevent? state :runner prevent type))
+           (if (and (not unpreventable) (not= cause :ability-cost) (cards-can-prevent? state :runner prevent type card args))
              (do (system-msg state :runner "has the option to prevent trash effects")
                  (show-wait-prompt state :corp "Runner to prevent trash effects" {:priority 10})
                  (show-prompt state :runner nil

--- a/test/clj/game_test/cards/resources.clj
+++ b/test/clj/game_test/cards/resources.clj
@@ -540,6 +540,37 @@
     (play-from-hand state :corp "Hedge Fund")
     (is (= 11 (:credit (get-corp))) "Corp has 11c")))
 
+(deftest dummy-box
+  ;; Dummy Box - trash a card from hand to prevent corp trashing installed card
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Dummy Box" 1) (qty "Cache" 1) (qty "Clot" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Dummy Box")
+    (play-from-hand state :runner "Cache")
+    (take-credits state :runner)
+    (core/trash state :runner (get-program state 0))
+    (is (not-empty (:prompt (get-runner))) "Dummy Box prompting to prevent program trash")
+    (card-ability state :runner (get-resource state 0) 2)
+    (prompt-select :runner (find-card "Clot" (:hand (get-runner))))
+    (prompt-choice :runner "Done")
+    (is (= 1 (count (:discard (get-runner)))) "Clot trashed")
+    (is (empty? (:hand (get-runner))) "Card trashed from hand")
+    (is (= 1 (count (get-in @state [:runner :rig :program]))) "Cache still installed")
+    (is (= 1 (count (get-in @state [:runner :rig :resource]))) "Dummy Box still installed")))
+
+(deftest dummy-box-purge
+  ;; Dummy Box - doesn't prevent program deletion during purge
+  (do-game
+    (new-game (default-corp)
+              (default-runner [(qty "Dummy Box" 1) (qty "Cache" 1) (qty "Clot" 1)]))
+    (take-credits state :corp)
+    (play-from-hand state :runner "Dummy Box")
+    (play-from-hand state :runner "Clot")
+    (take-credits state :runner)
+    (core/purge state :corp)
+    (is (empty? (:prompt (get-runner))) "Dummy Box not prompting to prevent purge trash")))
+
 (deftest eden-shard
   ;; Eden Shard - Install from Grip in lieu of accessing R&D; trash to make Corp draw 2
   (do-game


### PR DESCRIPTION
Working on `Dummy Box` and found a different set of requirements for prevention. Instead of just know what's doing the blocking, we need to know what's being targeted. For example, `Dummy Box` shouldn't fire on a `Purge`, but it doesn't know that internally. Instead I set it in the `trash` call from the programs that trash themselves when purged.

Open to refactoring, since I probably don't have the broader view on how you want to use this.

Fixes #2872